### PR TITLE
Proposed addition to module search view

### DIFF
--- a/public/base.css
+++ b/public/base.css
@@ -218,3 +218,10 @@ input[type="submit"] {
 	margin: 0;
 	margin-top: 15px;
 }
+
+#search .module .version {
+	margin-left: .6em;
+	color: #999;
+	font-weight: normal;
+	font-size: 70%;
+}

--- a/views/partials/modules.html
+++ b/views/partials/modules.html
@@ -3,7 +3,7 @@
 		<% if (mod.stars) { %>
 			<span class="stars"><%= mod.stars %></span>
 		<% } %>
-		<h2><a href="<%= mod.url %>"><%= mod.name %></a></h2>
+		<h2><a href="<%= mod.url %>"><%= mod.name %></a> <span class="version"><%= mod.version %></span></h2>
 		<div class="subline">
 			by <a href="<%= mod.profile %>" class="<%= mod.related ? 'following' : '' %>"><%= mod.author %></a>
 			<% if (mod.relation.length || mod.dependents) { %>


### PR DESCRIPTION
One of my secondary uses of NPM is to check what the current version of a package is. To improve the user experience of node-modules.com I think this is an important addition.

I've added the version at a central spot on the search results page, however toned down the text as it isn't of primary importance.
