### PR TITLE
Add link to the homepage from the about page

### DIFF
--- a/views/about.html
+++ b/views/about.html
@@ -10,6 +10,7 @@
 			<div id="about">
 				<p>Created by <a href="http://github.com/mafintosh" target="blank">Mathias Buus Madsen</a>, and <a href="http://github.com/freeall" target="blank">Tobias Baunbæk</a>.</p>
 				<p>You can contact us on <a href="http://twitter.com/node_modules" target="blank">Twitter</a>. If you don't like it, you can <a href="http://github.com/mafintosh/node-modules">fork us</a>.</p>
+				<a href="/">&lt;-- Go back to front page</a>
 				<%{ 'partials/menu.html' }%>
 			</div>
 		</div>


### PR DESCRIPTION
When you go to the about page, there is currently no way to go back to the index.
