### PR TITLE
Add links to npm for modules with github url

### DIFF
--- a/public/base.css
+++ b/public/base.css
@@ -226,3 +226,7 @@ input[type="submit"] {
 	font-weight: normal;
 	font-size: 14px;
 }
+
+#search .module .links {
+	margin: 15px 0 0;
+}

--- a/search-index/index.js
+++ b/search-index/index.js
@@ -54,6 +54,8 @@ var pack = function(mod, user) { // TODO: maybe optimize this as it is run A LOT
 
 var unpack = function(mod, packed) {
 	var gh = mod.github;
+	var npmUrl = 'https://npmjs.org/package/'+mod._id;
+	var ghUrl = gh && gh.url;
 	return {
 		name: mod._id,
 		author: gh && gh.username || mod.maintainer,
@@ -64,7 +66,9 @@ var unpack = function(mod, packed) {
 		stars: gh && gh.stars || 0,
 		dependents: mod.dependents.length,
 		description: mod.description,
-		url: gh && gh.url || 'https://npmjs.org/package/'+mod._id,
+		url: ghUrl || npmUrl,
+		gh_url: ghUrl,
+		npm_url: npmUrl,
 		marker: marker(mod._id, packed[1]),
 		version: mod.version
 	};

--- a/views/partials/modules.html
+++ b/views/partials/modules.html
@@ -20,5 +20,11 @@
 		<p class="description">
 			<%= mod.description %>
 		</p>
+		<% if (mod.gh_url) { %>
+		<p class="links">
+			<a href="<%= mod.npm_url %>">npm</a>
+			<a href="<%= mod.gh_url %>">github</a>
+		</p>
+		<% } %>
 	</div>
 <% }) %>


### PR DESCRIPTION
Just to say that I use node-modules almost daily and I really like it. Sometimes I'd like to check the module's details on NPM instead of going straight to GitHub repo, so I took an initial stab at adding the link:

![](https://cloud.githubusercontent.com/assets/616767/8768347/f6c0a3cc-2e7c-11e5-955a-2cc86e659cb8.png)

However this seems a bit redundant, plus the links are maybe too much unobtrusive; perhaps the npm link could be placed next to the package name, since the link already points to GitHub?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mafintosh/node-modules/26)

<!-- Reviewable:end -->
