### PR TITLE
Skip npm change-sets without any versions

### DIFF
--- a/modules/fetch.js
+++ b/modules/fetch.js
@@ -98,7 +98,7 @@ var lookup = function(name, opts, callback) {
 
 	getJSONRetry('http://registry.npmjs.org/'+enc(name), function(err, npm) {
 		if (err) return callback(); // deleted module
-		if (!npm.time) return callback();
+		if (!npm.time || !npm.versions) return callback();
 
 		var mod = {};
 		var repository = parseRepository(npm.repository) || parseRepository(npm.homepage);


### PR DESCRIPTION
This fixes parsing of newer npm data where the `versions` property is optional.

Fix for https://opbeat.com/mafintosh/node-modulescom/errors/4/