### PR TITLE
Don't fail if host isn't set

### DIFF
--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ app.on('route', function(request, response) {
 	var username = request.query.u || c.username || '';
 	if (request.query.u === '') username = '';
 
-	if (request.headers.host.indexOf('.node-modules.com') > -1) {
+	if (request.headers.host && request.headers.host.indexOf('.node-modules.com') > -1) {
 		setCookie = false;
 		username = request.headers.host.split('.')[0];
 		if (username === 'development' || username === 'www') username = '';


### PR DESCRIPTION
Some bots will not set a host header, e.g:

```
masscan/1.0 (https://github.com/robertdavidgraham/masscan)
```

Fix for https://opbeat.com/mafintosh/node-modulescom/errors/5/